### PR TITLE
Modbus 8E1 mode

### DIFF
--- a/Src/serial.c
+++ b/Src/serial.c
@@ -601,8 +601,12 @@ static bool serialSuspendInput (bool suspend)
 
 static bool serialSetBaudRate (uint32_t baud_rate)
 {
-    UART0->CR1 |= (USART_CR1_UE|USART_CR1_RXNEIE);
-    UART0->CR1 = USART_CR1_RE|USART_CR1_TE;
+    // UART0->CR1 |= (USART_CR1_UE|USART_CR1_RXNEIE);
+    UART0->CR1 = USART_CR1_RE|USART_CR1_TE
+#if UART0_PARITY_EVEN
+    | USART_CR1_PCE | USART_CR1_M0
+#endif
+    ;
     UART0->CR3 = USART_CR3_OVRDIS;
     UART0->BRR = UART_DIV_SAMPLING16(UART0_CLK, baud_rate, UART_PRESCALER_DIV1);
     UART0->CR1 |= (USART_CR1_UE|USART_CR1_RXNEIE);


### PR DESCRIPTION
Parity check on the modbus line is a very good thing to have in a noisy environment and all the professional vfds have it enabled by default anyway.

Add -D UART0_PARITY_EVEN into platformio.ini to enable 8E1.