### PR TITLE
Fix serial.c compiler errors with latest grblHAL core

### DIFF
--- a/Src/serial.c
+++ b/Src/serial.c
@@ -1113,7 +1113,8 @@ static bool serial2PutC (const uint8_t c)
 //
 static void serial2WriteS (const char *s)
 {
-    char c, *ptr = (char *)s;
+	const char *ptr = s;
+	char c;
 
     while((c = *ptr++) != '\0')
         serial2PutC(c);
@@ -1121,9 +1122,9 @@ static void serial2WriteS (const char *s)
 
 // Writes a number of characters from a buffer to the serial output stream, blocks if buffer full
 //
-static void serial2Write (const char *s, uint16_t length)
+static void serial2Write (const uint8_t *s, uint16_t length)
 {
-    char *ptr = (char *)s;
+	const uint8_t *ptr = s;
 
     while(length--)
         serial2PutC(*ptr++);
@@ -1208,7 +1209,7 @@ static bool serial2Disable (bool disable)
     return true;
 }
 
-static bool serial2EnqueueRtCommand (char c)
+static bool serial2EnqueueRtCommand (uint8_t c)
 {
     return enqueue_realtime_command2(c);
 }


### PR DESCRIPTION
This PR resolves compilation errors in the STM32H7xx driver by adjusting function signatures in `Src/serial.c` to match type definitions in the latest `grblHAL/core` (`grbl/stream.h`).

### Details of Changes:
- **`serial2WriteS`**: Fixed const-pointer assignment to avoid stripping the `const` qualifier from parameter `s`.
- **`serial2Write`**: Changed the signature to accept `const uint8_t *s` (instead of `const char *s`) to match the `.write_n` function pointer type in `io_stream_t`.
- **`serial2EnqueueRtCommand`**: Changed the signature to accept `uint8_t c` (instead of `char c`) to match the `.enqueue_rt_command` function pointer type in `io_stream_t`.